### PR TITLE
feat(docs): add jsdoc

### DIFF
--- a/src/lib/decorators/ApplyOptions.ts
+++ b/src/lib/decorators/ApplyOptions.ts
@@ -3,6 +3,23 @@ import type { Ctor } from '@sapphire/utilities';
 import { createClassDecorator } from './utils/createClassDecorator';
 import { createProxy } from './utils/createProxy';
 
+/**
+ * Decorator function that applies given options to {@link Middleware} piece.
+ * @since 2.0.0
+ * @param options The options to pass to the middleware constructor.
+ *
+ * @example
+ * ```typescript
+ * import { ApplyOptions, Middleware } from '@joshdb/core';
+ *
+ * (at)ApplyOptions<Middleware.Options>({
+ *   name: 'name',
+ *   position: 0,
+ *   conditions: []
+ * })
+ * export class CoreMiddleware extends Middleware {}
+ * ```
+ */
 export function ApplyOptions<T extends PieceOptions>(options: T): ClassDecorator {
 	return createClassDecorator((target: Ctor<ConstructorParameters<typeof Piece>, Piece>) =>
 		createProxy(target, {

--- a/src/lib/errors/JoshError.ts
+++ b/src/lib/errors/JoshError.ts
@@ -1,4 +1,12 @@
+/**
+ * The base class for errors in {@link Josh}
+ * @since 2.0.0
+ */
 export class JoshError extends Error {
+	/**
+	 * The identifier for this error.
+	 * @since 2.0.0
+	 */
 	public identifier: string;
 
 	public constructor(options: JoshError.Options) {
@@ -7,14 +15,30 @@ export class JoshError extends Error {
 		this.identifier = options.identifier;
 	}
 
+	/**
+	 * The name of this error.
+	 */
 	public get name() {
 		return 'JoshError';
 	}
 }
 
 export namespace JoshError {
+	/**
+	 * The options for {@link JoshError}
+	 * @since 2.0.0
+	 */
 	export interface Options {
+		/**
+		 * The identifier for this error.
+		 * @since 2.0.0
+		 */
 		identifier: string;
+
+		/**
+		 * The message for this error.
+		 * @since 2.0.0
+		 */
 		message?: string;
 	}
 }

--- a/src/lib/errors/JoshProviderError.ts
+++ b/src/lib/errors/JoshProviderError.ts
@@ -1,7 +1,15 @@
 import type { Method } from '../types';
 import { JoshError } from './JoshError';
 
+/**
+ * The base class for {@link JoshProvider}.
+ * @since 2.0.0
+ */
 export class JoshProviderError extends JoshError {
+	/**
+	 * The method this error applies to.
+	 * @since 2.0.0
+	 */
 	public method: Method;
 
 	public constructor(options: JoshProviderError.Options) {
@@ -10,13 +18,25 @@ export class JoshProviderError extends JoshError {
 		this.method = options.method;
 	}
 
+	/**
+	 * The name for this error.
+	 * @since 2.0.0
+	 */
 	public get name() {
 		return 'JoshProviderError';
 	}
 }
 
 export namespace JoshProviderError {
+	/**
+	 * The options for {@link JoshProviderError}
+	 * @since 2.0.0
+	 */
 	export interface Options extends JoshError.Options {
+		/**
+		 * The method this error applies to.
+		 * @since 2.0.0
+		 */
 		method: Method;
 	}
 }

--- a/src/lib/payloads/AutoKey.ts
+++ b/src/lib/payloads/AutoKey.ts
@@ -1,3 +1,7 @@
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `autoKey` using {@link Payload.Data}
+ * @since 2.0.0
+ */
 export interface AutoKeyPayload extends Payload, Payload.Data<string> {}

--- a/src/lib/payloads/AutoKey.ts
+++ b/src/lib/payloads/AutoKey.ts
@@ -2,7 +2,9 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `autoKey` using {@link Payload.Data}
+ * The payload for {@link Method.AutoKey}
+ * @see {@link Payload}
+ * @see {@link Payload.Data}
  * @since 2.0.0
  */
 export interface AutoKeyPayload extends Payload, Payload.Data<string> {

--- a/src/lib/payloads/Dec.ts
+++ b/src/lib/payloads/Dec.ts
@@ -1,3 +1,7 @@
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `dec` using {@link Payload.KeyPath} and {@link Payload.OptionalData}
+ * @since 2.0.0
+ */
 export interface DecPayload extends Payload, Payload.KeyPath, Payload.OptionalData<number> {}

--- a/src/lib/payloads/Dec.ts
+++ b/src/lib/payloads/Dec.ts
@@ -2,7 +2,10 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `dec` using {@link Payload.KeyPath} and {@link Payload.OptionalData}
+ * The payload for {@link Method.Dec}
+ * @see {@link Payload}
+ * @see {@link Payload.KeyPath}
+ * @see {@link Payload.OptionalData}
  * @since 2.0.0
  */
 export interface DecPayload extends Payload, Payload.KeyPath, Payload.OptionalData<number> {

--- a/src/lib/payloads/Delete.ts
+++ b/src/lib/payloads/Delete.ts
@@ -1,3 +1,7 @@
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `delete` using {@link Payload.KeyPath}
+ * @since 2.0.0
+ */
 export interface DeletePayload extends Payload, Payload.KeyPath {}

--- a/src/lib/payloads/Delete.ts
+++ b/src/lib/payloads/Delete.ts
@@ -2,7 +2,9 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `delete` using {@link Payload.KeyPath}
+ * The payload for {@link Method.Delete}
+ * @see {@link Payload}
+ * @see {@link Payload.KeyPath}
  * @since 2.0.0
  */
 export interface DeletePayload extends Payload, Payload.KeyPath {

--- a/src/lib/payloads/Ensure.ts
+++ b/src/lib/payloads/Ensure.ts
@@ -2,7 +2,9 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `ensure` using {@link Payload.Data}
+ * The payload for {@link Method.Ensure}
+ * @see {@link Payload}
+ * @see {@link Payload.Data}
  * @since 2.0.0
  */
 export interface EnsurePayload<Value = unknown> extends Payload, Payload.Data<Value> {

--- a/src/lib/payloads/Ensure.ts
+++ b/src/lib/payloads/Ensure.ts
@@ -1,7 +1,19 @@
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `ensure` using {@link Payload.Data}
+ * @since 2.0.0
+ */
 export interface EnsurePayload<Value = unknown> extends Payload, Payload.Data<Value> {
+	/**
+	 * The key for this payload.
+	 * @since 2.0.0
+	 */
 	key: string;
 
+	/**
+	 * The default value for this payload.
+	 * @since 2.0.0
+	 */
 	defaultValue: Value;
 }

--- a/src/lib/payloads/Filter.ts
+++ b/src/lib/payloads/Filter.ts
@@ -3,9 +3,13 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
+<<<<<<< HEAD
  * The union payload for {@link Method.Filter}
  * @see {@link Payload}
  * @see {@link Payload.OptionalData}
+=======
+ * The {@link Payload} for `filter using {@link Payload.OptionalData}
+>>>>>>> 8fc025f (docs: implemtned for `payloads/*`)
  * @since 2.0.0
  */
 export interface FilterPayload<Value = unknown> extends Payload, Payload.OptionalData<Record<string, Value | null>> {
@@ -41,10 +45,14 @@ export interface FilterPayload<Value = unknown> extends Payload, Payload.Optiona
 }
 
 /**
+<<<<<<< HEAD
  * The data payload for {@link Method.Filter}
  * @see {@link Payload}
  * @see {@link Payload.ByData}
  * @see {@link Payload.Data}
+=======
+ * The {@link Payload} for `filter` using {@link Payload.ByData} and {@link Payload.Data}
+>>>>>>> 8fc025f (docs: implemtned for `payloads/*`)
  * @since 2.0.0
  */
 export interface FilterByDataPayload<Value = unknown> extends Payload, Payload.ByData, Payload.Data<Record<string, Value>> {

--- a/src/lib/payloads/Filter.ts
+++ b/src/lib/payloads/Filter.ts
@@ -1,26 +1,74 @@
 import type { Awaited } from '@sapphire/utilities';
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `filter using {@link Payload.OptionalData}
+ * @since 2.0.0
+ */
 export interface FilterPayload<Value = unknown> extends Payload, Payload.OptionalData<Record<string, Value | null>> {
+	/**
+	 * The type for this payload.
+	 * @since 2.0.0
+	 */
 	type: Payload.Type;
 
+	/**
+	 * The input data for this payload.
+	 * @since 2.0.0
+	 */
 	inputData?: Value;
 
+	/**
+	 * The input hook for this payload.
+	 * @since 2.0.0
+	 */
 	inputHook?: FilterHook<Value>;
 
+	/**
+	 * The path for this payload.
+	 * @since 2.0.0
+	 */
 	path?: string[];
 }
 
+/**
+ * The {@link Payload} for `filter` using {@link Payload.ByData} and {@link Payload.Data}
+ * @since 2.0.0
+ */
 export interface FilterByDataPayload<Value = unknown> extends Payload, Payload.ByData, Payload.Data<Record<string, Value>> {
+	/**
+	 * The input data for this payload.
+	 * @since 2.0.0
+	 */
 	inputData: Value;
 
+	/**
+	 * The path for this payload.
+	 * @since 2.0.0
+	 */
 	path?: string[];
 }
 
+/**
+ * The {@link Payload} for `filter` using {@link Payload.ByHook} and {@link Payload.Data}
+ * @since 2.0.0
+ */
 export interface FilterByHookPayload<Value = unknown> extends Payload, Payload.ByHook, Payload.Data<Record<string, Value>> {
+	/**
+	 * The input hook for this payload.
+	 * @since 2.0.0
+	 */
 	inputHook: FilterHook<Value>;
 
+	/**
+	 * The path for this payload.
+	 * @since 2.0.0
+	 */
 	path?: string[];
 }
 
+/**
+ * The hook for {@link FilterByHookPayload}
+ * @since 2.0.0
+ */
 export type FilterHook<Value = unknown> = (data: Value) => Awaited<Value>;

--- a/src/lib/payloads/Filter.ts
+++ b/src/lib/payloads/Filter.ts
@@ -3,13 +3,9 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
-<<<<<<< HEAD
  * The union payload for {@link Method.Filter}
  * @see {@link Payload}
  * @see {@link Payload.OptionalData}
-=======
- * The {@link Payload} for `filter using {@link Payload.OptionalData}
->>>>>>> 8fc025f (docs: implemtned for `payloads/*`)
  * @since 2.0.0
  */
 export interface FilterPayload<Value = unknown> extends Payload, Payload.OptionalData<Record<string, Value | null>> {
@@ -45,14 +41,10 @@ export interface FilterPayload<Value = unknown> extends Payload, Payload.Optiona
 }
 
 /**
-<<<<<<< HEAD
  * The data payload for {@link Method.Filter}
  * @see {@link Payload}
  * @see {@link Payload.ByData}
  * @see {@link Payload.Data}
-=======
- * The {@link Payload} for `filter` using {@link Payload.ByData} and {@link Payload.Data}
->>>>>>> 8fc025f (docs: implemtned for `payloads/*`)
  * @since 2.0.0
  */
 export interface FilterByDataPayload<Value = unknown> extends Payload, Payload.ByData, Payload.Data<Record<string, Value>> {

--- a/src/lib/payloads/Filter.ts
+++ b/src/lib/payloads/Filter.ts
@@ -3,7 +3,9 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `filter using {@link Payload.OptionalData}
+ * The union payload for {@link Method.Filter}
+ * @see {@link Payload}
+ * @see {@link Payload.OptionalData}
  * @since 2.0.0
  */
 export interface FilterPayload<Value = unknown> extends Payload, Payload.OptionalData<Record<string, Value | null>> {
@@ -39,7 +41,10 @@ export interface FilterPayload<Value = unknown> extends Payload, Payload.Optiona
 }
 
 /**
- * The {@link Payload} for `filter` using {@link Payload.ByData} and {@link Payload.Data}
+ * The data payload for {@link Method.Filter}
+ * @see {@link Payload}
+ * @see {@link Payload.ByData}
+ * @see {@link Payload.Data}
  * @since 2.0.0
  */
 export interface FilterByDataPayload<Value = unknown> extends Payload, Payload.ByData, Payload.Data<Record<string, Value>> {
@@ -63,7 +68,10 @@ export interface FilterByDataPayload<Value = unknown> extends Payload, Payload.B
 }
 
 /**
- * The {@link Payload} for `filter` using {@link Payload.ByHook} and {@link Payload.Data}
+ * The hook payload for {@link Method.Filter}
+ * @see {@link Payload}
+ * @see {@link Payload.ByHook}
+ * @see {@link Payload.Data}
  * @since 2.0.0
  */
 export interface FilterByHookPayload<Value = unknown> extends Payload, Payload.ByHook, Payload.Data<Record<string, Value>> {

--- a/src/lib/payloads/Find.ts
+++ b/src/lib/payloads/Find.ts
@@ -11,6 +11,7 @@ import type { Payload } from './Payload';
 export interface FindPayload<Value = unknown> extends Payload, Payload.OptionalData<Value> {
 	/**
 	 * The method for this payload.
+	 * @since 2.0.0
 	 */
 	method: Method.Find;
 

--- a/src/lib/payloads/Find.ts
+++ b/src/lib/payloads/Find.ts
@@ -3,7 +3,9 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `find` using {@link Payload.OptionalData}
+ * The union payload for {@link Method.Find}
+ * @see {@link Payload}
+ * @see {@link Payload.OptionalData}
  * @since 2.0.0
  */
 export interface FindPayload<Value = unknown> extends Payload, Payload.OptionalData<Value> {
@@ -38,7 +40,10 @@ export interface FindPayload<Value = unknown> extends Payload, Payload.OptionalD
 }
 
 /**
- * The {@link Payload} for `find` using {@link Payload.ByData} and {@link Payload.OptionalData}
+ * The data payload for {@link Method.Find}
+ * @see {@link Payload}
+ * @see {@link Payload.ByData}
+ * @see {@link Payload.OptionalData}
  * @since 2.0.0
  */
 export interface FindByDataPayload<Value = unknown> extends Payload, Payload.ByData, Payload.OptionalData<Value> {
@@ -62,7 +67,10 @@ export interface FindByDataPayload<Value = unknown> extends Payload, Payload.ByD
 }
 
 /**
- * The {@link Payload} for `find` using {@link Payload.ByHook} and {@link Payload.OptionalData}
+ * The hook payload for {@link Method.Find}
+ * @see {@link Payload}
+ * @see {@link Payload.ByHook}
+ * @see {@link Payload.OptionalData}
  * @since 2.0.0
  */
 export interface FindByHookPayload<Value = unknown> extends Payload, Payload.ByHook, Payload.OptionalData<Value> {

--- a/src/lib/payloads/Find.ts
+++ b/src/lib/payloads/Find.ts
@@ -1,26 +1,73 @@
 import type { Awaited } from '@sapphire/utilities';
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `find` using {@link Payload.OptionalData}
+ * @since 2.0.0
+ */
 export interface FindPayload<Value = unknown> extends Payload, Payload.OptionalData<Value> {
+	/**
+	 * The type for this payload.
+	 * @since 2.0.0
+	 */
 	type: Payload.Type;
 
+	/**
+	 * The input data for this payload.
+	 * @since 2.0.0
+	 */
 	inputData?: Value;
 
+	/**
+	 * The input hook for this payload.
+	 * @since 2.0.0
+	 */
 	inputHook?: FindHook<Value>;
 
+	/**
+	 * The path for this payload.
+	 * @since 2.0.0
+	 */
 	path?: string[];
 }
 
+/**
+ * The {@link Payload} for `find` using {@link Payload.ByData} and {@link Payload.OptionalData}
+ * @since 2.0.0
+ */
 export interface FindByDataPayload<Value = unknown> extends Payload, Payload.ByData, Payload.OptionalData<Value> {
+	/**
+	 * The input data for this payload.
+	 * @since 2.0.0
+	 */
 	inputData: Value;
 
+	/**
+	 * The path for this payload.
+	 * @since 2.0.0
+	 */
 	path?: string[];
 }
 
+/**
+ * The {@link Payload} for `find` using {@link Payload.ByHook} and {@link Payload.OptionalData}
+ * @since 2.0.0
+ */
 export interface FindByHookPayload<Value = unknown> extends Payload, Payload.ByHook, Payload.OptionalData<Value> {
+	/**
+	 * The input hook for this payload.
+	 * @since 2.0.0
+	 */
 	inputHook: FindHook<Value>;
 
+	/**
+	 * The path for this payload.
+	 */
 	path?: string[];
 }
 
+/**
+ * The hook for {@link FindByHookPayload}
+ * @since 2.0.0
+ */
 export type FindHook<Value = unknown> = (data: Value) => Awaited<boolean>;

--- a/src/lib/payloads/Get.ts
+++ b/src/lib/payloads/Get.ts
@@ -2,7 +2,10 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `get` using {@link Payload.KeyPath} and {@link Payload.OptionalData}
+ * The payload for {@link Method.Get}
+ * @see {@link Payload}
+ * @see {@link Payload.KeyPath}
+ * @see {@link Payload.OptionalData}
  * @since 2.0.0
  */
 export interface GetPayload<Value = unknown> extends Payload, Payload.KeyPath, Payload.OptionalData<Value> {

--- a/src/lib/payloads/Get.ts
+++ b/src/lib/payloads/Get.ts
@@ -1,3 +1,7 @@
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `get` using {@link Payload.KeyPath} and {@link Payload.OptionalData}
+ * @since 2.0.0
+ */
 export interface GetPayload<Value = unknown> extends Payload, Payload.KeyPath, Payload.OptionalData<Value> {}

--- a/src/lib/payloads/GetAll.ts
+++ b/src/lib/payloads/GetAll.ts
@@ -2,7 +2,9 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `getAll` using {@link Payload.Data}
+ * The payload for {@link Method.GetAll}
+ * @see {@link Payload}
+ * @see {@link Payload.Data}
  * @since 2.0.0
  */
 export interface GetAllPayload<Value = unknown> extends Payload, Payload.Data<Record<string, Value>> {

--- a/src/lib/payloads/GetAll.ts
+++ b/src/lib/payloads/GetAll.ts
@@ -1,3 +1,7 @@
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `getAll` using {@link Payload.Data}
+ * @since 2.0.0
+ */
 export interface GetAllPayload<Value = unknown> extends Payload, Payload.Data<Record<string, Value>> {}

--- a/src/lib/payloads/GetMany.ts
+++ b/src/lib/payloads/GetMany.ts
@@ -1,6 +1,14 @@
 import type { KeyPathArray } from '../types';
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `getMany` using {@link Payload.Data}
+ * @since 2.0.0
+ */
 export interface GetManyPayload<Value = unknown> extends Payload, Payload.Data<Record<string, Value | null>> {
+	/**
+	 * The key/paths for this payload.
+	 * @since 2.0.0
+	 */
 	keyPaths: KeyPathArray[];
 }

--- a/src/lib/payloads/GetMany.ts
+++ b/src/lib/payloads/GetMany.ts
@@ -2,7 +2,9 @@ import type { KeyPathArray, Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `getMany` using {@link Payload.Data}
+ * The payload for {@link Method.GetMany}
+ * @see {@link Payload}
+ * @see {@link Payload.Data}
  * @since 2.0.0
  */
 export interface GetManyPayload<Value = unknown> extends Payload, Payload.Data<Record<string, Value | null>> {

--- a/src/lib/payloads/Has.ts
+++ b/src/lib/payloads/Has.ts
@@ -1,3 +1,7 @@
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `has` using {@link Payload.KeyPath} and {@link Payload.Data}
+ * @since 2.0.0
+ */
 export interface HasPayload extends Payload, Payload.KeyPath, Payload.Data<boolean> {}

--- a/src/lib/payloads/Has.ts
+++ b/src/lib/payloads/Has.ts
@@ -2,7 +2,10 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `has` using {@link Payload.KeyPath} and {@link Payload.Data}
+ * The payload for {@link Method.Has}
+ * @see {@link Payload}
+ * @see {@link Payload.KeyPath}
+ * @see {@link Payload.Data}
  * @since 2.0.0
  */
 export interface HasPayload extends Payload, Payload.KeyPath, Payload.Data<boolean> {

--- a/src/lib/payloads/Inc.ts
+++ b/src/lib/payloads/Inc.ts
@@ -2,7 +2,10 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `inc` using {@link Payload.KeyPath} and {@link Payload.OptionalData}
+ * The payload for {@link Method.Inc}
+ * @see {@link Payload}
+ * @see {@link Payload.KeyPath}
+ * @see {@link Payload.OptionalData}
  * @since 2.0.0
  */
 export interface IncPayload extends Payload, Payload.KeyPath, Payload.OptionalData<number> {

--- a/src/lib/payloads/Inc.ts
+++ b/src/lib/payloads/Inc.ts
@@ -1,3 +1,7 @@
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `inc` using {@link Payload.KeyPath} and {@link Payload.OptionalData}
+ * @since 2.0.0
+ */
 export interface IncPayload extends Payload, Payload.KeyPath, Payload.OptionalData<number> {}

--- a/src/lib/payloads/Keys.ts
+++ b/src/lib/payloads/Keys.ts
@@ -9,7 +9,7 @@ import type { Payload } from './Payload';
  */
 export interface KeysPayload extends Payload, Payload.Data<string[]> {
 	/**
-	 * THe method for this payload.
+	 * The method for this payload.
 	 * @since 2.0.0
 	 */
 	method: Method.Keys;

--- a/src/lib/payloads/Keys.ts
+++ b/src/lib/payloads/Keys.ts
@@ -1,3 +1,7 @@
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `keys` using {@link Payload.Data}
+ * @since 2.0.0
+ */
 export interface KeysPayload extends Payload, Payload.Data<string[]> {}

--- a/src/lib/payloads/Keys.ts
+++ b/src/lib/payloads/Keys.ts
@@ -2,7 +2,9 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `keys` using {@link Payload.Data}
+ * The payload for {@link Method.Keys}
+ * @see {@link Payload}
+ * @see {@link Payload.Data}
  * @since 2.0.0
  */
 export interface KeysPayload extends Payload, Payload.Data<string[]> {

--- a/src/lib/payloads/Payload.ts
+++ b/src/lib/payloads/Payload.ts
@@ -2,40 +2,112 @@ import type { Stopwatch } from '@sapphire/stopwatch';
 import type { JoshProviderError } from '../errors';
 import type { Method, Trigger } from '../types';
 
+/**
+ * The base payload to use for most Josh structures.
+ * @since 2.0.0
+ */
 export interface Payload {
+	/**
+	 * The method for this payload.
+	 * @since 2.0.0
+	 */
 	method: Method;
 
+	/**
+	 * The trigger for this payload.
+	 * @since 2.0.0
+	 */
 	trigger?: Trigger;
 
+	/**
+	 * The stopwatch to be used in the provider.
+	 * @since 2.0.0
+	 */
 	stopwatch?: Stopwatch;
 
+	/**
+	 * The error for this payload.
+	 * @since 2.0.0
+	 */
 	error?: JoshProviderError;
 }
 
 export namespace Payload {
+	/**
+	 * The key/path extension for {@link Payload}.
+	 * @since 2.0.0
+	 */
 	export interface KeyPath {
+		/**
+		 * The key for this extension.
+		 * @since 2.0.0
+		 */
 		key: string;
 
+		/**
+		 * The path for this extension.
+		 * @since 2.0.0
+		 */
 		path?: string[];
 	}
 
+	/**
+	 * The data extension for {@link Payload}.
+	 * @since 2.0.0
+	 */
 	export interface Data<Value = unknown> {
+		/**
+		 * The data for this extension.
+		 * @since 2.0.0
+		 */
 		data: Value;
 	}
 
+	/**
+	 * The optional data extension for {@link Payload}.
+	 * @since 2.0.0
+	 */
 	export type OptionalData<Value = unknown> = Partial<Data<Value>>;
 
+	/**
+	 * The byData extension for {@link Payload}.
+	 * @since 2.0.0
+	 */
 	export interface ByData {
+		/**
+		 * The type for this extension.
+		 * @since 2.0.0
+		 */
 		type: Type.Data;
 	}
 
+	/**
+	 * The byHook extension for {@link Payload}
+	 * @since 2.0.0
+	 */
 	export interface ByHook {
+		/**
+		 * The type for this extension.
+		 * @since 2.0.0
+		 */
 		type: Type.Hook;
 	}
 
+	/**
+	 * The type enum for {@link Payload}.
+	 * @since 2.0.0
+	 */
 	export enum Type {
+		/**
+		 * The data type.
+		 * @since 2.0.0
+		 */
 		Data = 'DATA',
 
+		/**
+		 * The hook type.
+		 * @since 2.0.0
+		 */
 		Hook = 'HOOK'
 	}
 }

--- a/src/lib/payloads/Payload.ts
+++ b/src/lib/payloads/Payload.ts
@@ -65,6 +65,7 @@ export namespace Payload {
 
 	/**
 	 * The optional data extension for {@link Payload}.
+	 * @see {@link Data}
 	 * @since 2.0.0
 	 */
 	export type OptionalData<Value = unknown> = Partial<Data<Value>>;

--- a/src/lib/payloads/Push.ts
+++ b/src/lib/payloads/Push.ts
@@ -1,3 +1,7 @@
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `push` using {@link Payload.KeyPath}
+ * @since 2.0.0
+ */
 export interface PushPayload extends Payload, Payload.KeyPath {}

--- a/src/lib/payloads/Push.ts
+++ b/src/lib/payloads/Push.ts
@@ -2,7 +2,9 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `push` using {@link Payload.KeyPath}
+ * The payload for {@link Method.Push}
+ * @see {@link Payload}
+ * @see {@link Payload.KeyPath}
  * @since 2.0.0
  */
 export interface PushPayload extends Payload, Payload.KeyPath {

--- a/src/lib/payloads/Random.ts
+++ b/src/lib/payloads/Random.ts
@@ -1,3 +1,7 @@
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `random` using {@link Payload.OptionalData}
+ * @since 2.0.0
+ */
 export interface RandomPayload<Value = unknown> extends Payload, Payload.OptionalData<Value> {}

--- a/src/lib/payloads/Random.ts
+++ b/src/lib/payloads/Random.ts
@@ -2,7 +2,9 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `random` using {@link Payload.OptionalData}
+ * The payload for {@link Method.Random}
+ * @see {@link Payload}
+ * @see {@link Payload.OptionalData}
  * @since 2.0.0
  */
 export interface RandomPayload<Value = unknown> extends Payload, Payload.OptionalData<Value> {

--- a/src/lib/payloads/RandomKey.ts
+++ b/src/lib/payloads/RandomKey.ts
@@ -1,3 +1,7 @@
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `randomKey` using {@link Payload.OptionalData}
+ * @since 2.0.0
+ */
 export interface RandomKeyPayload extends Payload, Partial<Payload.Data<string>> {}

--- a/src/lib/payloads/RandomKey.ts
+++ b/src/lib/payloads/RandomKey.ts
@@ -2,7 +2,9 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `randomKey` using {@link Payload.OptionalData}
+ * The payload for {@link Method.RandomKey}
+ * @see {@link Payload}
+ * @see {@link Payload.OptionalData}
  * @since 2.0.0
  */
 export interface RandomKeyPayload extends Payload, Partial<Payload.Data<string>> {

--- a/src/lib/payloads/Set.ts
+++ b/src/lib/payloads/Set.ts
@@ -2,7 +2,9 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `set` using {@link Payload.KeyPath}
+ * The payload for {@link Method.Set}
+ * @see {@link Payload}
+ * @see {@link Payload.KeyPath}
  * @since 2.0.0
  */
 export interface SetPayload extends Payload, Payload.KeyPath {

--- a/src/lib/payloads/Set.ts
+++ b/src/lib/payloads/Set.ts
@@ -1,3 +1,7 @@
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `set` using {@link Payload.KeyPath}
+ * @since 2.0.0
+ */
 export interface SetPayload extends Payload, Payload.KeyPath {}

--- a/src/lib/payloads/SetMany.ts
+++ b/src/lib/payloads/SetMany.ts
@@ -1,6 +1,14 @@
 import type { KeyPathArray } from '../types';
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `setMany`
+ * @since 2.0.0
+ */
 export interface SetManyPayload extends Payload {
+	/**
+	 * The key/paths for this payload.
+	 * @since 2.0.0
+	 */
 	keyPaths: KeyPathArray[];
 }

--- a/src/lib/payloads/SetMany.ts
+++ b/src/lib/payloads/SetMany.ts
@@ -2,7 +2,8 @@ import type { KeyPathArray, Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `setMany`
+ * The payload for {@link Method.SetMany}
+ * @see {@link Payload}
  * @since 2.0.0
  */
 export interface SetManyPayload extends Payload {

--- a/src/lib/payloads/Size.ts
+++ b/src/lib/payloads/Size.ts
@@ -2,7 +2,9 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `size` using {@link Payload.Data}
+ * The payload for {@link Method.Size}
+ * @see {@link Payload}
+ * @see {@link Payload.Data}
  * @since 2.0.0
  */
 export interface SizePayload extends Payload, Payload.Data<number> {

--- a/src/lib/payloads/Size.ts
+++ b/src/lib/payloads/Size.ts
@@ -1,3 +1,7 @@
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `size` using {@link Payload.Data}
+ * @since 2.0.0
+ */
 export interface SizePayload extends Payload, Payload.Data<number> {}

--- a/src/lib/payloads/Some.ts
+++ b/src/lib/payloads/Some.ts
@@ -3,7 +3,9 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `some` using {@link Payload.Data}
+ * The union payload for {@link Method.Some}
+ * @see {@link Payload}
+ * @see {@link Payload.Data}
  * @since 2.0.0
  */
 export interface SomePayload<Value = unknown> extends Payload, Payload.Data<boolean> {
@@ -39,7 +41,10 @@ export interface SomePayload<Value = unknown> extends Payload, Payload.Data<bool
 }
 
 /**
- * The {@link Payload} for `some` using {@link Payload.ByData} and {@link Payload.Data}
+ * The data payload for {@link Method.Some}
+ * @see {@link Payload}
+ * @see {@link Payload.ByData}
+ * @see {@link Payload.Data}
  * @since 2.0.0
  */
 export interface SomeByDataPayload<Value = unknown> extends Payload, Payload.ByData, Payload.Data<boolean> {
@@ -63,7 +68,10 @@ export interface SomeByDataPayload<Value = unknown> extends Payload, Payload.ByD
 }
 
 /**
- * The {@link Payload} for `some` using {@link Payload.ByHook} and {@link Payload.Data}
+ * The hook payload for {@link Method.Some}
+ * @see {@link Payload}
+ * @see {@link Payload.ByHook}
+ * @see {@link Payload.Data}
  * @since 2.0.0
  */
 export interface SomeByHookPayload<Value = unknown> extends Payload, Payload.ByHook, Payload.Data<boolean> {

--- a/src/lib/payloads/Some.ts
+++ b/src/lib/payloads/Some.ts
@@ -3,9 +3,13 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
+<<<<<<< HEAD
  * The union payload for {@link Method.Some}
  * @see {@link Payload}
  * @see {@link Payload.Data}
+=======
+ * The {@link Payload} for `some` using {@link Payload.Data}
+>>>>>>> 8fc025f (docs: implemtned for `payloads/*`)
  * @since 2.0.0
  */
 export interface SomePayload<Value = unknown> extends Payload, Payload.Data<boolean> {
@@ -84,7 +88,8 @@ export interface SomeByHookPayload<Value = unknown> extends Payload, Payload.ByH
 	/**
 	 * The input hook for this payload.
 	 * @since 2.0.0
-	 */ inputHook: SomeHook<Value>;
+	 */
+	inputHook: SomeHook<Value>;
 
 	/**
 	 * The path for this payload.

--- a/src/lib/payloads/Some.ts
+++ b/src/lib/payloads/Some.ts
@@ -1,26 +1,74 @@
 import type { Awaited } from '@sapphire/utilities';
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `some` using {@link Payload.Data}
+ * @since 2.0.0
+ */
 export interface SomePayload<Value = unknown> extends Payload, Payload.Data<boolean> {
+	/**
+	 * The type for this payload.
+	 * @since 2.0.0
+	 */
 	type: Payload.Type;
 
+	/**
+	 * The input data for this payload.
+	 * @since 2.0.0
+	 */
 	inputData?: Value;
 
+	/**
+	 * The input hook for this payload.
+	 * @since 2.0.0
+	 */
 	inputHook?: SomeHook<Value>;
 
+	/**
+	 * The path for this payload.
+	 * @since 2.0.0
+	 */
 	path?: string[];
 }
 
+/**
+ * The {@link Payload} for `some` using {@link Payload.ByData} and {@link Payload.Data}
+ * @since 2.0.0
+ */
 export interface SomeByDataPayload<Value = unknown> extends Payload, Payload.ByData, Payload.Data<boolean> {
+	/**
+	 * The input data for this payload.
+	 * @since 2.0.0
+	 */
 	inputData: Value;
 
+	/**
+	 * The path for this payload.
+	 * @since 2.0.0
+	 */
 	path?: string[];
 }
 
+/**
+ * The {@link Payload} for `some` using {@link Payload.ByHook} and {@link Payload.Data}
+ * @since 2.0.0
+ */
 export interface SomeByHookPayload<Value = unknown> extends Payload, Payload.ByHook, Payload.Data<boolean> {
+	/**
+	 * The input hook for this payload.
+	 * @since 2.0.0
+	 */
 	inputHook: SomeHook<Value>;
 
+	/**
+	 * The path for this payload.
+	 * @since 2.0.0
+	 */
 	path?: string[];
 }
 
+/**
+ * The hook for {@link SomeByHookPayload}
+ * @since 2.0.0
+ */
 export type SomeHook<Value = unknown> = (data: Value) => Awaited<boolean>;

--- a/src/lib/payloads/Some.ts
+++ b/src/lib/payloads/Some.ts
@@ -3,13 +3,9 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
-<<<<<<< HEAD
  * The union payload for {@link Method.Some}
  * @see {@link Payload}
  * @see {@link Payload.Data}
-=======
- * The {@link Payload} for `some` using {@link Payload.Data}
->>>>>>> 8fc025f (docs: implemtned for `payloads/*`)
  * @since 2.0.0
  */
 export interface SomePayload<Value = unknown> extends Payload, Payload.Data<boolean> {

--- a/src/lib/payloads/Update.ts
+++ b/src/lib/payloads/Update.ts
@@ -36,7 +36,6 @@ export interface UpdatePayload<Value = unknown> extends Payload, Payload.KeyPath
 }
 
 /**
-<<<<<<< HEAD
  * The data payload for {@link Method.Update}
  * @see {@link Payload}
  * @see {@link Payload.ByData}

--- a/src/lib/payloads/Update.ts
+++ b/src/lib/payloads/Update.ts
@@ -1,20 +1,55 @@
 import type { Awaited } from '@sapphire/utilities';
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `update` using {@link Payload.KeyPath} and {@link Payload.OptionalData}
+ * @since 2.0.0
+ */
 export interface UpdatePayload<Value = unknown> extends Payload, Payload.KeyPath, Payload.OptionalData<Value> {
+	/**
+	 * The type for this payload.
+	 * @since 2.0.0
+	 */
 	type: Payload.Type;
 
+	/**
+	 * The input data for this payload.
+	 * @since 2.0.0
+	 */
 	inputData?: Value;
 
+	/**
+	 * The input hook for this payload.
+	 * @since 2.0.0
+	 */
 	inputHook?: UpdateHook<Value>;
 }
 
+/**
+ * The {@link Payload} for `update` using {@link Payload.ByData}, {@link Payload.KeyPath}, and {@link Payload.OptionalData}
+ * @since 2.0.0
+ */
 export interface UpdateByDataPayload<Value = unknown> extends Payload, Payload.ByData, Payload.KeyPath, Payload.OptionalData<Value> {
+	/**
+	 * The input data for this payload.
+	 * @since 2.0.0
+	 */
 	inputData: Value;
 }
 
+/**
+ * The {@link Payload} for `update` using {@link Payload.ByHook}, {@link Payload.KeyPath}, and {@link Payload.OptionalData}
+ * @since 2.0.0
+ */
 export interface UpdateByHookPayload<Value = unknown> extends Payload, Payload.ByHook, Payload.KeyPath, Payload.OptionalData<Value> {
+	/**
+	 * The input hook for this payload.
+	 * @since 2.0.0
+	 */
 	inputHook: UpdateHook<Value>;
 }
 
+/**
+ * The hook for {@link UpdateByHookPayload}
+ */
 export type UpdateHook<Value = unknown> = (currentData: Value) => Awaited<Value>;

--- a/src/lib/payloads/Update.ts
+++ b/src/lib/payloads/Update.ts
@@ -3,7 +3,10 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `update` using {@link Payload.KeyPath} and {@link Payload.OptionalData}
+ * The union payload for {@link Method.Update}
+ * @see {@link Payload}
+ * @see {@link Payload.KeyPath}
+ * @see {@link Payload.OptionalData}
  * @since 2.0.0
  */
 export interface UpdatePayload<Value = unknown> extends Payload, Payload.KeyPath, Payload.OptionalData<Value> {
@@ -32,22 +35,33 @@ export interface UpdatePayload<Value = unknown> extends Payload, Payload.KeyPath
 }
 
 /**
- * The {@link Payload} for `update` using {@link Payload.ByData}, {@link Payload.KeyPath}, and {@link Payload.OptionalData}
+ * The data payload for {@link Method.Update}
+ * @see {@link Payload}
+ * @see {@link Payload.ByData}
+ * @see {@link Payload.KeyPath}
+ * @see {@link Payload.OptionalData}
  * @since 2.0.0
  */
 export interface UpdateByDataPayload<Value = unknown> extends Payload, Payload.ByData, Payload.KeyPath, Payload.OptionalData<Value> {
 	/**
 	 * The method for this payload.
-	 * @since 2.0.0 */ method: Method.Update;
+	 * @since 2.0.0
+	 */
+	method: Method.Update;
 
 	/**
 	 * The input data for this payload.
 	 * @since 2.0.0
-	 */ inputData: Value;
+	 */
+	inputData: Value;
 }
 
 /**
- * The {@link Payload} for `update` using {@link Payload.ByHook}, {@link Payload.KeyPath}, and {@link Payload.OptionalData}
+ * The hook payload for {@link Method.Update}
+ * @see {@link Payload}
+ * @see {@link Payload.ByHook}
+ * @see {@link Payload.KeyPath}
+ * @see {@link Payload.OptionalData}
  * @since 2.0.0
  */
 export interface UpdateByHookPayload<Value = unknown> extends Payload, Payload.ByHook, Payload.KeyPath, Payload.OptionalData<Value> {
@@ -60,7 +74,8 @@ export interface UpdateByHookPayload<Value = unknown> extends Payload, Payload.B
 	/**
 	 * The input hook for this payload.
 	 * @since 2.0.0
-	 */ inputHook: UpdateHook<Value>;
+	 */
+	inputHook: UpdateHook<Value>;
 }
 
 /**

--- a/src/lib/payloads/Update.ts
+++ b/src/lib/payloads/Update.ts
@@ -19,7 +19,8 @@ export interface UpdatePayload<Value = unknown> extends Payload, Payload.KeyPath
 	/**
 	 * The type for this payload.
 	 * @since 2.0.0
-	 */ type: Payload.Type;
+	 */
+	type: Payload.Type;
 
 	/**
 	 * The input data for this payload.
@@ -35,6 +36,7 @@ export interface UpdatePayload<Value = unknown> extends Payload, Payload.KeyPath
 }
 
 /**
+<<<<<<< HEAD
  * The data payload for {@link Method.Update}
  * @see {@link Payload}
  * @see {@link Payload.ByData}

--- a/src/lib/payloads/Values.ts
+++ b/src/lib/payloads/Values.ts
@@ -2,7 +2,9 @@ import type { Method } from '../types';
 import type { Payload } from './Payload';
 
 /**
- * The {@link Payload} for `values` using {@link Payload.Data}
+ * The payload for {@link Method.Values}
+ * @see {@link Payload}
+ * @see {@link Payload.Data}
  * @since 2.0.0
  */
 export interface ValuesPayload<Value = unknown> extends Payload, Payload.Data<Value[]> {

--- a/src/lib/payloads/Values.ts
+++ b/src/lib/payloads/Values.ts
@@ -1,3 +1,7 @@
 import type { Payload } from './Payload';
 
+/**
+ * The {@link Payload} for `values` using {@link Payload.Data}
+ * @since 2.0.0
+ */
 export interface ValuesPayload<Value = unknown> extends Payload, Payload.Data<Value[]> {}

--- a/src/lib/structures/Josh.ts
+++ b/src/lib/structures/Josh.ts
@@ -43,10 +43,9 @@ import { MiddlewareStore } from './MiddlewareStore';
 
 /**
  * The base class that makes Josh work.
- *
  * @see {@link Josh.Options} for all options available to the Josh class.
- *
  * @since 2.0.0
+ *
  * @example
  * ```typescript
  * const josh = new Josh({

--- a/src/lib/structures/Josh.ts
+++ b/src/lib/structures/Josh.ts
@@ -58,7 +58,7 @@ import { MiddlewareStore } from './MiddlewareStore';
  * ```typescript
  * // Using a provider.
  * const josh = new Josh({
- *   provider: new MapProvider(),
+ *   provider: new Provider(),
  *   // More options...
  * });
  * ```

--- a/src/lib/structures/Josh.ts
+++ b/src/lib/structures/Josh.ts
@@ -41,13 +41,79 @@ import { JoshProvider } from './JoshProvider';
 import type { Middleware } from './Middleware';
 import { MiddlewareStore } from './MiddlewareStore';
 
+/**
+ * The base class that makes Josh work.
+ *
+ * @see {@link Josh.Options} for all options available to the Josh class.
+ *
+ * @since 2.0.0
+ * @example
+ * ```typescript
+ * const josh = new Josh({
+ *   name: 'name',
+ *   // More options...
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Using a provider.
+ * const josh = new Josh({
+ *   provider: new MapProvider(),
+ *   // More options...
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Automatically scan from a specific directory.
+ * // The main file is at `/hom/me/project/index.js`
+ * // and all your pieces are at `/home/me/project/middlewares`
+ * // NOTE: Do not use this option unless you know what you're doing.
+ * const josh = new Josh({
+ *   middlewareDirectory: join(__dirname, 'middlewares'),
+ *   // More options
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Using middleware context
+ * const josh = new Josh({
+ *   middlewareContextData: {
+ *     [BuiltInMiddleware.AutoEnsure]: {
+ *       defaultValue: 'value'
+ *     }
+ *   },
+ *   // More options...
+ * });
+ */
 export class Josh<Value = unknown> {
+	/**
+	 * This Josh's name. Used for middleware and/or provider information.
+	 * @since 2.0.0
+	 */
 	public name: string;
 
+	/**
+	 * This Josh's options. Used throughout the instance.
+	 * @since 2.0.0
+	 */
 	public options: Josh.Options<Value>;
 
+	/**
+	 * The middleware store.
+	 *
+	 * NOTE: Do not use this unless you know what your doing.
+	 * @since 2.0.0
+	 */
 	public middlewares: MiddlewareStore;
 
+	/**
+	 * This Josh's provider instance.
+	 *
+	 * NOTE: Do not use this unless you know what your doing.
+	 */
 	public provider: JoshProvider<Value>;
 
 	public constructor(options: Josh.Options<Value>) {
@@ -72,6 +138,18 @@ export class Josh<Value = unknown> {
 			.registerPath(join(__dirname, '..', '..', 'middlewares'));
 	}
 
+	/**
+	 * Generate an automatic key. Generally an integer incremented by `1`, but depends on provider.
+	 * @since 2.0.0
+	 * @returns The newly generated automatic key.
+	 *
+	 * @example
+	 * ```typescript
+	 * const key = await josh.autoKey();
+	 *
+	 * await josh.set(key, 'value');
+	 * ```
+	 */
 	public async autoKey(): Promise<string> {
 		let payload: AutoKeyPayload = { method: Method.AutoKey, trigger: Trigger.PreProvider, data: '' };
 
@@ -89,6 +167,21 @@ export class Josh<Value = unknown> {
 		return payload.data;
 	}
 
+	/**
+	 * Decrement an integer by `1`.
+	 * @since 2.0.0
+	 * @param keyPath The key/path to the integer for decrementing.
+	 * @returns The {@link Josh} instance.
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.set('key', 1);
+	 *
+	 * await josh.dec('key');
+	 *
+	 * await josh.get('key'); // 0
+	 * ```
+	 */
 	public async dec(keyPath: KeyPath): Promise<this> {
 		const [key, path] = this.getKeyPath(keyPath);
 		let payload: DecPayload = { method: Method.Dec, trigger: Trigger.PreProvider, key, path };
@@ -107,6 +200,30 @@ export class Josh<Value = unknown> {
 		return this;
 	}
 
+	/**
+	 * Deletes a key or path in a key value.
+	 * @since 2.0.0
+	 * @param keyPath The key/path to delete from.
+	 * @returns The {@link Josh} instance.
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.set('key', 'value');
+	 *
+	 * await josh.delete('key');
+	 *
+	 * await josh.get('key'); // null
+	 * ```
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.set('key', { key: 'value' });
+	 *
+	 * await josh.delete(['key', ['key']]);
+	 *
+	 * await josh.get('key'); // {}
+	 * ```
+	 */
 	public async delete(keyPath: KeyPath): Promise<this> {
 		const [key, path] = this.getKeyPath(keyPath);
 		let payload: DeletePayload = { method: Method.Delete, trigger: Trigger.PreProvider, key, path };
@@ -125,6 +242,25 @@ export class Josh<Value = unknown> {
 		return this;
 	}
 
+	/**
+	 * Ensure a key exists and set a default value if it doesn't.
+	 * @since 2.0.0
+	 * @param key The key to ensure.
+	 * @param defaultValue The default value to set if the key doesn't exist.
+	 * @returns The value gotten from the key.
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.ensure('key', 'defaultValue'); // 'defaultValue'
+	 * ```
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.set('key', 'value');
+	 *
+	 * await josh.ensure('key', 'defaultValue'); // 'value'
+	 * ```
+	 */
 	public async ensure<CustomValue = Value>(key: string, defaultValue: CustomValue): Promise<CustomValue> {
 		let payload: EnsurePayload<CustomValue> = { method: Method.Ensure, trigger: Trigger.PreProvider, key, data: defaultValue, defaultValue };
 
@@ -142,18 +278,40 @@ export class Josh<Value = unknown> {
 		return payload.data;
 	}
 
+	/**
+	 * Filter data using a path and value.
+	 * @since 2.0.0
+	 * @param path The path array to check on stored data.
+	 * @param value The value to check against the data at path.
+	 * @param returnBulkType The return bulk type. Defaults to {@link Bulk.Object}
+	 * @returns The bulk data.
+	 */
 	public async filter<CustomValue = Value, K extends keyof ReturnBulk<CustomValue> = Bulk.Object>(
 		path: string[],
 		value: CustomValue,
 		returnBulkType?: K
 	): Promise<ReturnBulk<CustomValue>[K]>;
 
+	/** Filter data using a function and optional path.
+	 * @since 2.0.0
+	 * @param hook The function to run on stored data.
+	 * @param path The optional path array to get on stored data and pass to the function.
+	 * @param returnBulkType The return bulk type. Defaults to {@link Bulk.Object}
+	 * @returns The bulk data.
+	 */
 	public async filter<CustomValue = Value, K extends keyof ReturnBulk<CustomValue> = Bulk.Object>(
 		hook: FilterHook<CustomValue>,
 		path?: string[],
 		returnBulkType?: K
 	): Promise<ReturnBulk<CustomValue>[K]>;
 
+	/**
+	 * Filter data using a path and value or function and optional path.
+	 * @param pathOrHook The path array or function.
+	 * @param pathOrValue The value or path array.
+	 * @param returnBulkType The return bulk type. Defaults to {@link Bulk.Object}
+	 * @returns The bulk data.
+	 */
 	public async filter<CustomValue = Value, K extends keyof ReturnBulk<CustomValue> = Bulk.Object>(
 		pathOrHook: string[] | FilterHook<CustomValue>,
 		pathOrValue?: string[] | CustomValue,
@@ -215,8 +373,30 @@ export class Josh<Value = unknown> {
 		return this.convertBulkData(payload.data, returnBulkType);
 	}
 
+	/**
+	 * Find data using a path and value.
+	 * @since 2.0.0
+	 * @param path The path array to check on stored data.
+	 * @param value The value to check against the data at path.
+	 * @returns The data found or `null`.
+	 */
 	public async find<CustomValue = Value>(path: string[], value: CustomValue): Promise<CustomValue>;
+
+	/**
+	 * Find data using a function and optional path.
+	 * @since 2.0.0
+	 * @param hook The function to run on stored data.
+	 * @param path The optional path array to get on stored data and pass to the function.
+	 * @returns The data found or `null`.
+	 */
 	public async find<CustomValue = Value>(hook: FindHook<CustomValue>, path?: string[]): Promise<CustomValue | null>;
+
+	/**
+	 * Find data using a path and value or function and optional path.
+	 * @param pathOrHook The path array or function.
+	 * @param pathOrValue The value or path array.
+	 * @returns The data found or `null`.
+	 */
 	public async find<CustomValue = Value>(
 		pathOrHook: string[] | FindHook<CustomValue>,
 		pathOrValue?: string[] | CustomValue
@@ -270,6 +450,26 @@ export class Josh<Value = unknown> {
 		return payload.data ?? null;
 	}
 
+	/**
+	 * Get data at a specific key/path.
+	 * @since 2.0.0
+	 * @param keyPath The key/path to get data from.
+	 * @returns The data found or `null`.
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.set('key', 'value');
+	 *
+	 * await josh.get('key'); // 'value'
+	 * ```
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.set('key', { path: 'value' });
+	 *
+	 * await josh.get(['key', ['path']]); // 'value'
+	 * ```
+	 */
 	public async get<CustomValue = Value>(keyPath: KeyPath): Promise<CustomValue | null> {
 		const [key, path] = this.getKeyPath(keyPath);
 		let payload: GetPayload<CustomValue> = { method: Method.Get, trigger: Trigger.PreProvider, key, path };
@@ -288,6 +488,30 @@ export class Josh<Value = unknown> {
 		return payload.data ?? null;
 	}
 
+	/**
+	 * Get all data.
+	 * @since 2.0.0
+	 * @param returnBulkType The return bulk type. Defaults to {@link Bulk.Object}
+	 * @returns The bulk data.
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.set('key', 'value');
+	 *
+	 * await josh.getAll(); // { key: 'value' }
+	 * // Using a return bulk type.
+	 * await josh.getAll(Bulk.OneDimensionalArray); // ['value']
+	 * ```
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.set('key', { path: 'value' });
+	 *
+	 * await josh.getAll(); // { key: { path: 'value' } }
+	 * // Using a return bulk type.
+	 * await josh.getAll(Bulk.TwoDimensionalArray); // [['key', { path: 'value' }]]
+	 * ```
+	 */
 	public async getAll<CustomValue = Value, K extends keyof ReturnBulk<CustomValue> = Bulk.Object>(
 		returnBulkType?: K
 	): Promise<ReturnBulk<CustomValue>[K]> {
@@ -307,6 +531,31 @@ export class Josh<Value = unknown> {
 		return this.convertBulkData(payload.data, returnBulkType);
 	}
 
+	/**
+	 * Get data at many key/paths.
+	 * @since 2.0.0
+	 * @param keyPaths The key/paths to get from.
+	 * @param returnBulkType The return bulk type. Defaults to {@link Bulk.Object}
+	 * @returns The bulk data.
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.set('key', 'value');
+	 *
+	 * await josh.getMany([['key', []]]); // { key: 'value' };
+	 * // Using a return bulk type.
+	 * await josh.getMany([['key', []]], Bulk.OneDimensionalArray); // ['value']
+	 * ```
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.set('key', { path: 'value' });
+	 *
+	 * await josh.getMany([['key', ['path']]]); // { key: 'value' }
+	 * // Using a return bulk type.
+	 * await josh.getMany([['key', ['path]]], Bulk.TwoDimensionalArray); // [['key', 'value']]
+	 * ```
+	 */
 	public async getMany<CustomValue = Value, K extends keyof ReturnBulk<CustomValue> = Bulk.Object>(
 		keyPaths: KeyPathArray[],
 		returnBulkType?: K
@@ -345,6 +594,21 @@ export class Josh<Value = unknown> {
 		return payload.data;
 	}
 
+	/**
+	 * Increment an integer by `1`.
+	 * @since 2.0.0
+	 * @param keyPath The key/path to the integer for incrementing.
+	 * @returns The {@link Josh} instance.
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.set('key', 0);
+	 *
+	 * await josh.inc('key');
+	 *
+	 * await josh.get('key'); // 1
+	 * ```
+	 */
 	public async inc(keyPath: KeyPath): Promise<this> {
 		const [key, path] = this.getKeyPath(keyPath);
 		let payload: IncPayload = { method: Method.Inc, trigger: Trigger.PreProvider, key, path };
@@ -363,6 +627,18 @@ export class Josh<Value = unknown> {
 		return this;
 	}
 
+	/**
+	 * Get an array of keys.
+	 * @since 2.0.0
+	 * @returns The array of string keys.
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.set('key', 'value');
+	 *
+	 * await josh.keys(); // ['key']
+	 * ```
+	 */
 	public async keys(): Promise<string[]> {
 		let payload: KeysPayload = { method: Method.Keys, trigger: Trigger.PreProvider, data: [] };
 
@@ -380,6 +656,13 @@ export class Josh<Value = unknown> {
 		return payload.data;
 	}
 
+	/**
+	 * Push a value to an array at a specific key/value.
+	 * @since 2.0.0
+	 * @param keyPath The key/path to the array for pushing.
+	 * @param value The value to push to the array.
+	 * @returns The {@link Josh} instance.
+	 */
 	public async push<CustomValue = Value>(keyPath: KeyPath, value: CustomValue): Promise<this> {
 		const [key, path] = this.getKeyPath(keyPath);
 		let payload: PushPayload = { method: Method.Push, trigger: Trigger.PreProvider, key, path };
@@ -398,6 +681,11 @@ export class Josh<Value = unknown> {
 		return this;
 	}
 
+	/**
+	 * Get a random value.
+	 * @since 2.0.0
+	 * @returns The random data or `null`.
+	 */
 	public async random<CustomValue = Value>(): Promise<CustomValue | null> {
 		let payload: RandomPayload<CustomValue> = { method: Method.Random, trigger: Trigger.PreProvider };
 
@@ -415,6 +703,11 @@ export class Josh<Value = unknown> {
 		return payload.data ?? null;
 	}
 
+	/**
+	 * Get a random key.
+	 * @since 2.0.0
+	 * @returns The random key or `null`.
+	 */
 	public async randomKey(): Promise<string | null> {
 		let payload: RandomKeyPayload = { method: Method.RandomKey, trigger: Trigger.PreProvider };
 
@@ -432,6 +725,20 @@ export class Josh<Value = unknown> {
 		return payload.data ?? null;
 	}
 
+	/**
+	 * Set data at a specific key/path.
+	 * @since 2.0.0
+	 * @param keyPath The key/path to the data for setting.
+	 * @param value The value to set at the key/path.
+	 * @returns The {@link Josh} instance.
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.set('key', 'value');
+	 *
+	 * await josh.get('key'); // 'value';
+	 * ```
+	 */
 	public async set<CustomValue = Value>(keyPath: KeyPath, value: CustomValue): Promise<this> {
 		const [key, path] = this.getKeyPath(keyPath);
 		let payload: SetPayload = { method: Method.Set, trigger: Trigger.PreProvider, key, path };
@@ -450,6 +757,20 @@ export class Josh<Value = unknown> {
 		return this;
 	}
 
+	/**
+	 * Set data at many key/paths.
+	 * @since 2.0.0
+	 * @param keyPaths The key/paths to the data for setting.
+	 * @param value The value to set at the key/paths.
+	 * @returns The {@link Josh} instance.
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.setMany([['key', []]], 'value');
+	 *
+	 * await josh.getMany([['key', []]]); // { key: 'value' }
+	 * ```
+	 */
 	public async setMany<CustomValue = Value>(keyPaths: [string, string[]][], value: CustomValue): Promise<this> {
 		let payload: SetManyPayload = { method: Method.SetMany, trigger: Trigger.PreProvider, keyPaths };
 
@@ -467,6 +788,16 @@ export class Josh<Value = unknown> {
 		return this;
 	}
 
+	/**
+	 * Get the amount of key/values
+	 * @since 2.0.0
+	 * @returns The number amount.
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.size(); // 0
+	 * ```
+	 */
 	public async size(): Promise<number> {
 		let payload: SizePayload = { method: Method.Size, trigger: Trigger.PreProvider, data: 0 };
 
@@ -484,8 +815,31 @@ export class Josh<Value = unknown> {
 		return payload.data;
 	}
 
+	/**
+	 * Check if data matches with a path and value.
+	 * @since 2.0.0
+	 * @param path The path array to check on stored data.
+	 * @param value The value to check against the data at path.
+	 * @returns Whether the data check is `true` or `false`.
+	 */
 	public async some<CustomValue = Value>(path: string[], value: CustomValue): Promise<boolean>;
+
+	/**
+	 * Check if data matches with a function and optional path.
+	 * @since 2.0.0
+	 * @param hook  The function to run on stored data.
+	 * @param path The optional path array to get on stored data and pass to the function.
+	 * @returns Whether the data check is `true` or `false`.
+	 */
 	public async some<CustomValue = Value>(hook: SomeHook<CustomValue>, path?: string[]): Promise<boolean>;
+
+	/**
+	 * Check if data matches with a path and value or function and optional path.
+	 * @since 2.0.0
+	 * @param pathOrHook The path array or function.
+	 * @param pathOrValue The value or path array.
+	 * @returns Whether the data check is `true` or `false`.
+	 */
 	public async some<CustomValue = Value>(pathOrHook: string[] | SomeHook<CustomValue>, pathOrValue?: string[] | CustomValue): Promise<boolean> {
 		if (Array.isArray(pathOrHook)) {
 			if (pathOrValue === undefined)
@@ -540,6 +894,31 @@ export class Josh<Value = unknown> {
 		return payload.data;
 	}
 
+	/**
+	 * Update data at a specific key/path.
+	 * @since 2.0.0
+	 * @param keyPath The key/path to data for updating.
+	 * @param inputDataOrHook The input, either a value or a function.
+	 * @returns The updated value or `null` if the data doesn't exist.
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.set('key', 'value');
+	 *
+	 * await josh.update('key', 'anotherValue'); // 'anotherValue'
+	 * ```
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.set('key', { path: 'value' })
+	 *
+	 * await josh.update('key', (data) => {
+	 *   data.anotherPath = 'anotherValue';
+	 *
+	 *   return data;
+	 * }); // { path: 'value', anotherPath: 'anotherValue' }
+	 * ```
+	 */
 	public async update<CustomValue = Value>(keyPath: KeyPath, inputDataOrHook: CustomValue | UpdateHook<CustomValue>): Promise<CustomValue | null> {
 		const [key, path] = this.getKeyPath(keyPath);
 
@@ -582,6 +961,19 @@ export class Josh<Value = unknown> {
 		return payload.data ?? null;
 	}
 
+	/**
+	 * Get all data values.
+	 * @since 2.0.0
+	 * @returns An array of data values.
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.set('key', 'value');
+	 * await josh.set('anotherKey', 'anotherValue');
+	 *
+	 * await josh.values(); // ['value', 'anotherValue']
+	 * ```
+	 */
 	public async values<CustomValue = Value>(): Promise<CustomValue[]> {
 		let payload: ValuesPayload<CustomValue> = { method: Method.Values, trigger: Trigger.PreProvider, data: [] };
 
@@ -599,6 +991,16 @@ export class Josh<Value = unknown> {
 		return payload.data;
 	}
 
+	/**
+	 * The initialization method for Josh.
+	 * @since 2.0.0
+	 * @returns The {@link Josh} instance
+	 *
+	 * @example
+	 * ```typescript
+	 * await josh.init();
+	 * ```
+	 */
 	public async init(): Promise<this> {
 		await this.middlewares.loadAll();
 
@@ -609,6 +1011,11 @@ export class Josh<Value = unknown> {
 		return this;
 	}
 
+	/**
+	 * Enables a middleware that was not enabled by default.
+	 * @since 2.0.0
+	 * @param name The name of the middleware to enable.
+	 */
 	public use(name: BuiltInMiddleware): this;
 	public use(name: string): this {
 		const middleware = this.middlewares.get(name);
@@ -622,6 +1029,12 @@ export class Josh<Value = unknown> {
 		return this;
 	}
 
+	/** A protected method for converting bulk data.
+	 * @since 2.0.0
+	 * @param data The data to convert.
+	 * @param returnBulkType The return bulk type. Defaults to {@link Bulk.Object}
+	 * @returns The bulk data.
+	 */
 	protected convertBulkData<CustomValue = Value, K extends keyof ReturnBulk<CustomValue> = Bulk.Object>(
 		data: ReturnBulk<CustomValue>[Bulk.Object],
 		returnBulkType?: K
@@ -644,12 +1057,25 @@ export class Josh<Value = unknown> {
 		}
 	}
 
+	/**
+	 * A protected method for extracting the key/path from a {@link KeyPath} type.
+	 * @since 2.0.0
+	 * @param keyPath The key/path to extract from.
+	 * @returns The extracted key/path data.
+	 */
 	protected getKeyPath(keyPath: KeyPath): [string, string[] | undefined] {
 		if (typeof keyPath === 'string') return [keyPath, undefined];
 
 		return keyPath;
 	}
 
+	/**
+	 * A static method to create multiple instances of {@link Josh}.
+	 * @since 2.0.0
+	 * @param names The names to give each instance of {@link Josh}
+	 * @param options The options to give all the instances.
+	 * @returns
+	 */
 	public static multi<Instances extends Record<string, Josh> = Record<string, Josh>>(
 		names: string[],
 		options: Omit<Josh.Options, 'name'> = {}
@@ -664,13 +1090,33 @@ export class Josh<Value = unknown> {
 }
 
 export namespace Josh {
+	/**
+	 * The options for {@link Josh}.
+	 * @since 2.0.0
+	 */
 	export interface Options<Value = unknown> {
+		/**
+		 * The name for the Josh instance.
+		 * @since 2.0.0
+		 */
 		name?: string;
 
+		/**
+		 * The provider instance.
+		 * @since 2.0.0
+		 */
 		provider?: JoshProvider<Value>;
 
+		/**
+		 * The middleware directory.
+		 * @since 2.0.0
+		 */
 		middlewareDirectory?: string;
 
+		/**
+		 * The middleware context data.
+		 * @since 2.0.0
+		 */
 		middlewareContextData?: MiddlewareContextData<Value>;
 	}
 
@@ -717,6 +1163,10 @@ export interface ReturnBulk<T = unknown> {
 	[K: string]: Record<string, T | null> | Map<string, T | null> | (T | null)[] | [string, T | null][];
 }
 
+/**
+ * The context data for middlewares. Indexed by their keys being the name of the middleware.
+ * @since 2.0.0
+ */
 export interface MiddlewareContextData<T = unknown> {
 	[BuiltInMiddleware.AutoEnsure]?: AutoEnsureContext<T>;
 

--- a/src/lib/structures/JoshProvider.ts
+++ b/src/lib/structures/JoshProvider.ts
@@ -29,17 +29,60 @@ import type {
 } from '../payloads';
 import type { Josh } from './Josh';
 
+/**
+ * The base provider class. Extend this class to create your own provider.
+ *
+ * NOTE: If you want an example of how to use this class please see `src/lib/structures/defaultProvider/MapProvider.ts`
+ *
+ * @see {@link JoshProvider.Options} for all options available to the JoshProvider class.
+ *
+ * @since 2.0.0
+ * @example
+ * ```typescript
+ * export class Provider extends JoshProvider {
+ *   // Implement methods...
+ * }
+ * ```
+ */
 export abstract class JoshProvider<Value = unknown> {
+	/**
+	 * The name for this provider.
+	 * @since 2.0.0
+	 */
 	public name?: string;
 
+	/**
+	 * The {@link Josh} instance for this provider.
+	 * @since 2.0.0
+	 */
 	public instance?: Josh<Value>;
 
+	/**
+	 * The options for this provider.
+	 * @since 2.0.0
+	 */
 	public options: JoshProvider.Options;
 
 	public constructor(options: JoshProvider.Options = {}) {
 		this.options = options;
 	}
 
+	/**
+	 * Initialize the provider.
+	 * @since 2.0.0
+	 * @param context The provider's context sent by this provider's {@link Josh} instance.
+	 * @returns The provider's context.
+	 *
+	 * @example
+	 * ```typescript
+	 * public async init(context: JoshProvider.Context<Value>): Promise<JoshProvider.Context<Value>> {
+	 *   // Initialize provider...
+	 *   context = await super.init(context);
+	 *   // Initialize provider...
+	 *   return context;
+	 * }
+	 * ```
+	 */
 	public async init(context: JoshProvider.Context<Value>): Promise<JoshProvider.Context<Value>> {
 		const { name, instance } = context;
 
@@ -49,65 +92,219 @@ export abstract class JoshProvider<Value = unknown> {
 		return Promise.resolve(context);
 	}
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract autoKey(payload: AutoKeyPayload): Awaited<AutoKeyPayload>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract dec(payload: DecPayload): Awaited<DecPayload>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract delete(payload: DeletePayload): Awaited<DeletePayload>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract ensure<CustomValue = Value>(payload: EnsurePayload<CustomValue>): Awaited<EnsurePayload<CustomValue>>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract filterByData<CustomValue = Value>(payload: FilterByDataPayload<CustomValue>): Awaited<FilterByDataPayload<CustomValue>>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract filterByHook<CustomValue = Value>(payload: FilterByHookPayload<CustomValue>): Awaited<FilterByHookPayload<CustomValue>>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract findByData<CustomValue = Value>(payload: FindByDataPayload<CustomValue>): Awaited<FindByDataPayload<CustomValue>>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract findByHook<CustomValue = Value>(payload: FindByHookPayload<CustomValue>): Awaited<FindByHookPayload<CustomValue>>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract get<CustomValue = Value>(payload: GetPayload<CustomValue>): Awaited<GetPayload<CustomValue>>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract getAll<CustomValue = Value>(payload: GetAllPayload<CustomValue>): Awaited<GetAllPayload<CustomValue>>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract getMany<CustomValue = Value>(payload: GetManyPayload<CustomValue>): Awaited<GetManyPayload<CustomValue>>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract has(payload: HasPayload): Awaited<HasPayload>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract inc(payload: IncPayload): Awaited<IncPayload>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract keys(payload: KeysPayload): Awaited<KeysPayload>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract push<CustomValue = Value>(payload: PushPayload, value: CustomValue): Awaited<PushPayload>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract random<CustomValue = Value>(payload: RandomPayload<CustomValue>): Awaited<RandomPayload<CustomValue>>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract randomKey(payload: RandomKeyPayload): Awaited<RandomKeyPayload>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract set<CustomValue = Value>(payload: SetPayload, value: CustomValue): Awaited<SetPayload>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract setMany<CustomValue = Value>(payload: SetManyPayload, value: CustomValue): Awaited<SetManyPayload>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract size(payload: SizePayload): Awaited<SizePayload>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract someByData<CustomValue = Value>(payload: SomeByDataPayload<CustomValue>): Awaited<SomeByDataPayload<CustomValue>>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract someByHook<CustomValue = Value>(payload: SomeByHookPayload<CustomValue>): Awaited<SomeByHookPayload<CustomValue>>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract updateByData<CustomValue = Value>(payload: UpdateByDataPayload<CustomValue>): Awaited<UpdateByDataPayload<CustomValue>>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract updateByHook<CustomValue = Value>(payload: UpdateByHookPayload<CustomValue>): Awaited<UpdateByHookPayload<CustomValue>>;
 
+	/**
+	 * @since 2.0.0
+	 * @param payload The payload sent by this provider's {@link Josh} instance.
+	 * @returns The payload (modified), originally sent by this provider's {@link Josh} instance.
+	 */
 	public abstract values<CustomValue = Value>(payload: ValuesPayload<CustomValue>): Awaited<ValuesPayload<CustomValue>>;
 }
 
 export namespace JoshProvider {
+	/**
+	 * The options to extend for {@link JoshProvider}
+	 * @since 2.0.0
+	 *
+	 * @example
+	 * ```typescript
+	 * export namespace Provider {
+	 *   export interface Options extends JoshProvider.Options {
+	 *     // Provider options...
+	 *   }
+	 * }
+	 * ```
+	 */
 	export interface Options {}
 
+	/**
+	 * The context sent by the {@link Josh} instance.
+	 * @since 2.0.0
+	 */
 	export interface Context<Value = unknown> {
+		/**
+		 * The name of this context.
+		 * @since 2.0.0
+		 */
 		name: string;
 
+		/**
+		 * The instance of this context.
+		 * @since 2.0.0
+		 */
 		instance?: Josh<Value>;
 
+		/**
+		 * The error of this context.
+		 * @since 2.0.0
+		 */
 		error?: JoshProviderError;
 	}
 }

--- a/src/lib/structures/Middleware.ts
+++ b/src/lib/structures/Middleware.ts
@@ -35,13 +35,46 @@ import type {
 import { Method, Trigger } from '../types';
 import type { MiddlewareStore } from './MiddlewareStore';
 
+/**
+ * The base class piece for creating middlewares. Extend this piece to create a middleware.
+ * @see {@link Middleware.Options} for all available options for middlewares.
+ * @since 2.0.0
+ *
+ * @example
+ * ```typescript
+ * (at)ApplyOptions<MiddlewareOptions>({
+ *   name: 'middleware',
+ *   // More options...
+ * })
+ * export class CoreMiddleware extends Middleware {
+ *   // Make method implementations...
+ * }
+ * ```
+ */
 export abstract class Middleware<Context extends Middleware.Context = Middleware.Context> extends Piece {
+	/**
+	 * The store for this middleware.
+	 * @since 2.0.0
+	 */
 	public declare store: MiddlewareStore;
 
+	/**
+	 * The position of this middleware.
+	 * @since 2.0.0
+	 */
 	public readonly position?: number;
 
+	/**
+	 * The conditions of this middleware.
+	 * @since 2.0.0
+	 */
 	public readonly conditions: Middleware.Condition[];
 
+	/**
+	 * Whether to use this middleware or not.
+	 * @since 2.0.0
+	 * @default true
+	 */
 	public use: boolean;
 
 	public constructor(context: PieceContext, options: Middleware.Options = {}) {
@@ -156,35 +189,79 @@ export abstract class Middleware<Context extends Middleware.Context = Middleware
 		return { ...super.toJSON(), position: this.position, conditions: this.conditions, use: this.use };
 	}
 
+	/**
+	 * Retrieve this middleware'es context data from the Josh instance.
+	 * @since 2.0.0
+	 * @returns The context or `undefined`
+	 */
 	protected getContext<C extends Middleware.Context = Context>(): C | undefined {
 		const contextData = this.instance.options.middlewareContextData ?? {};
 
 		return Reflect.get(contextData, this.name);
 	}
 
+	/**
+	 * Get this middleware's Josh instance.
+	 * @since 2.0.0
+	 */
 	protected get instance() {
 		return this.store.instance;
 	}
 
+	/**
+	 * Get this middleware's provider instance.
+	 * @since 2.0.0
+	 */
 	protected get provider() {
 		return this.instance.provider;
 	}
 }
 
 export namespace Middleware {
+	/**
+	 * The options for {@link Middleware}
+	 * @since 2.0.0
+	 */
 	export interface Options extends PieceOptions {
+		/**
+		 * The position at which this middleware runs at.
+		 * @since 2.0.0
+		 */
 		position?: number;
 
+		/**
+		 * The conditions for this middleware to run on.
+		 * @since 2.0.0
+		 */
 		conditions?: Condition[];
 
+		/**
+		 * Whether this middleware is enabled or not.
+		 * @since 2.0.0
+		 */
 		use?: boolean;
 	}
 
+	/**
+	 * The middleware context base interface.
+	 * @since 2.0.0
+	 */
 	export interface Context {}
 
+	/**
+	 * A middleware condition to run on.
+	 * @since 2.0.0
+	 */
 	export interface Condition {
+		/**
+		 * The methods for this condition.
+		 * @since 2.0.0
+		 */
 		methods: Method[];
 
+		/**
+		 * The trigger for this condition.
+		 */
 		trigger: Trigger;
 	}
 

--- a/src/lib/structures/MiddlewareStore.ts
+++ b/src/lib/structures/MiddlewareStore.ts
@@ -3,7 +3,14 @@ import type { Method, Trigger } from '../types';
 import type { Josh } from './Josh';
 import { Middleware } from './Middleware';
 
+/**
+ * The store to contain {@link Middleware} pieces.
+ * @since 2.0.0
+ */
 export class MiddlewareStore<Value = unknown> extends Store<Middleware> {
+	/**
+	 * The {@link Josh} instance for this store.
+	 */
 	public instance: Josh<Value>;
 
 	public constructor(options: MiddlewareStoreOptions<Value>) {
@@ -14,6 +21,13 @@ export class MiddlewareStore<Value = unknown> extends Store<Middleware> {
 		this.instance = instance;
 	}
 
+	/**
+	 * Filter middlewares by their conditions.
+	 * @since 2.0.0
+	 * @param method The method to filter by.
+	 * @param trigger The trigger to filter by.
+	 * @returns An array of middleware's in which the method and trigger matched.
+	 */
 	public filterByCondition(method: Method, trigger: Trigger): Middleware[] {
 		const middlewares = this.array().filter(
 			(middleware) => middleware.use && middleware.conditions.some((c) => c.methods!.includes(method) && c.trigger === trigger)
@@ -26,6 +40,14 @@ export class MiddlewareStore<Value = unknown> extends Store<Middleware> {
 	}
 }
 
+/**
+ * The options for {@link MiddlewareStore}
+ * @since 2.0.0
+ */
 export interface MiddlewareStoreOptions<Value = unknown> {
+	/**
+	 * The {@link Josh} instance for this store.
+	 * @since 2.0.0
+	 */
 	instance: Josh<Value>;
 }

--- a/src/lib/structures/defaultProvider/MapProvider.ts
+++ b/src/lib/structures/defaultProvider/MapProvider.ts
@@ -32,9 +32,22 @@ import { Method } from '../../types';
 import { JoshProvider } from '../JoshProvider';
 import { MapProviderError } from './MapProviderError';
 
+/**
+ * A provider that uses the Node.js native [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) class.
+ * @since 2.0.0
+ */
 export class MapProvider<Value = unknown> extends JoshProvider<Value> {
+	/**
+	 * The [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) cache to store data.
+	 * @since 2.0.0
+	 * @private
+	 */
 	private cache = new Map<string, Value>();
 
+	/**
+	 * A simple cache for the {@link MapProvider.autoKey} method.
+	 * @since 2.0.0
+	 */
 	private autoKeyCount = 0;
 
 	public autoKey(payload: AutoKeyPayload): AutoKeyPayload {

--- a/src/lib/structures/defaultProvider/MapProviderError.ts
+++ b/src/lib/structures/defaultProvider/MapProviderError.ts
@@ -1,6 +1,13 @@
 import { JoshProviderError } from '../../errors';
 
+/**
+ * The error class for the MapProvider.
+ * @since 2.0.0
+ */
 export class MapProviderError extends JoshProviderError {
+	/**
+	 * The name for this error.
+	 */
 	public get name() {
 		return 'MapProviderError';
 	}

--- a/src/lib/validators/payloads/Filter.ts
+++ b/src/lib/validators/payloads/Filter.ts
@@ -1,10 +1,22 @@
 import { FilterByDataPayload, FilterByHookPayload, FilterPayload, Payload } from '../../payloads';
 import { Method } from '../../types';
 
+/**
+ * Checks whether the given payload is a {@link FilterByDataPayload}
+ * @since 2.0.0
+ * @param payload The payload to check
+ * @returns Whether the check is `true` or `false`
+ */
 export function isFilterByDataPayload<Value = unknown>(payload: FilterPayload<Value>): payload is FilterByDataPayload<Value> {
 	return payload.type === Payload.Type.Data && payload.method === Method.Filter;
 }
 
+/**
+ * Checks whether the given payload is a {@link FilterByHookPayload}
+ * @since 2.0.0
+ * @param payload The payload to check
+ * @returns Whether the check is `true` or `false`
+ */
 export function isFilterByHookPayload<Value = unknown>(payload: FilterPayload<Value>): payload is FilterByHookPayload<Value> {
 	return payload.type === Payload.Type.Hook && payload.method === Method.Filter;
 }

--- a/src/lib/validators/payloads/Find.ts
+++ b/src/lib/validators/payloads/Find.ts
@@ -1,10 +1,22 @@
 import { FindByDataPayload, FindByHookPayload, FindPayload, Payload } from '../../payloads';
 import { Method } from '../../types';
 
+/**
+ * Checks whether the given payload is a {@link FindByDataPayload}
+ * @since 2.0.0
+ * @param payload The payload to check
+ * @returns Whether the check is `true` or `false`
+ */
 export function isFindByDataPayload<Value = unknown>(payload: FindPayload<Value>): payload is FindByDataPayload<Value> {
 	return payload.type === Payload.Type.Data && payload.method === Method.Find;
 }
 
+/**
+ * Checks whether the given payload is a {@link FindByHookPayload}
+ * @since 2.0.0
+ * @param payload The payload to check
+ * @returns Whether the check is `true` or `false`
+ */
 export function isFindByHookPayload<Value = unknown>(payload: FindPayload<Value>): payload is FindByHookPayload<Value> {
 	return payload.type === Payload.Type.Hook && payload.method === Method.Find;
 }

--- a/src/lib/validators/payloads/Some.ts
+++ b/src/lib/validators/payloads/Some.ts
@@ -1,10 +1,22 @@
 import { Payload, SomeByDataPayload, SomeByHookPayload, SomePayload } from '../../payloads';
 import { Method } from '../../types';
 
+/**
+ * Checks whether the given payload is a {@link SomeByDataPayload}
+ * @since 2.0.0
+ * @param payload The payload to check
+ * @returns Whether the check is `true` or `false`
+ */
 export function isSomeByDataPayload<Value = unknown>(payload: SomePayload<Value>): payload is SomeByDataPayload<Value> {
 	return payload.type === Payload.Type.Data && payload.method === Method.Some;
 }
 
+/**
+ * Checks whether the given payload is a {@link SomeByHookPayload}
+ * @since 2.0.0
+ * @param payload The payload to check
+ * @returns Whether the check is `true` or `false`
+ */
 export function isSomeByHookPayload<Value = unknown>(payload: SomePayload<Value>): payload is SomeByHookPayload<Value> {
 	return payload.type === Payload.Type.Hook && payload.method === Method.Some;
 }

--- a/src/lib/validators/payloads/Update.ts
+++ b/src/lib/validators/payloads/Update.ts
@@ -1,10 +1,22 @@
 import { Payload, UpdateByDataPayload, UpdateByHookPayload, UpdatePayload } from '../../payloads';
 import { Method } from '../../types';
 
+/**
+ * Checks whether the given payload is a {@link UpdateByDataPayload}
+ * @since 2.0.0
+ * @param payload The payload to check
+ * @returns Whether the check is `true` or `false`
+ */
 export function isUpdateByDataPayload<Value = unknown>(payload: UpdatePayload<Value>): payload is UpdateByDataPayload<Value> {
 	return payload.type === Payload.Type.Data && payload.method === Method.Update;
 }
 
+/**
+ * Checks whether the given payload is a {@link UpdateByHookPayload}
+ * @since 2.0.0
+ * @param payload The payload to check
+ * @returns Whether the check is `true` or `false`
+ */
 export function isUpdateByHookPayload<Value = unknown>(payload: UpdatePayload<Value>): payload is UpdateByHookPayload<Value> {
 	return payload.type === Payload.Type.Hook && payload.method === Method.Update;
 }


### PR DESCRIPTION
This PR implements documentation for the entire core package.

- [x] [`src/lib/decorators/ApplyOptions.ts`](https://github.com/RealShadowNova/joshdb-core/blob/feat/add-documentation/src/lib/decorators/ApplyOptions.ts)
- [x] [`src/lib/errors/*`](https://github.com/RealShadowNova/joshdb-core/tree/feat/add-documentation/src/lib/errors)
- [x] [`src/lib/payloads/*`](https://github.com/RealShadowNova/joshdb-core/tree/feat/add-documentation/src/lib/payloads)
- [x] [`src/lib/structures/*`](https://github.com/RealShadowNova/joshdb-core/tree/feat/add-documentation/src/lib/structures)
- [x] [`src/lib/validators/*`](https://github.com/RealShadowNova/joshdb-core/tree/feat/add-documentation/src/lib/validators)